### PR TITLE
feat: implement getEnv method for workers

### DIFF
--- a/src/worker/createWorker.ts
+++ b/src/worker/createWorker.ts
@@ -59,5 +59,8 @@ export function createWorker(
       if (!env) return;
       return getHover({ env, path, pos });
     },
+    getEnv() {
+        return env
+    }
   };
 }


### PR DESCRIPTION
When using WebWorkers to interact with the Typescript API, there is currently no way to reference the underlying typescript environment. If users need to implement some ad-hoc feature not supported by the library, say, emitting the output of the editor, they must create a secondary interface to the WebWorker. With this change, it allows that user to simply:

```ts
const env = await worker.getEnv()
const output = env.languageService.getEmitOutput(path)
```



This is not a problem for those using the Typescript API on the main thread, as they must already have a reference to the environment.

