### PR TITLE
Use default import for ts

### DIFF
--- a/src/autocomplete/getAutocompletion.ts
+++ b/src/autocomplete/getAutocompletion.ts
@@ -3,13 +3,15 @@ import type {
   Completion,
   CompletionResult,
 } from "@codemirror/autocomplete";
-import { ScriptElementKind } from "typescript";
+import ts from "typescript";
 import { type VirtualTypeScriptEnvironment } from "@typescript/vfs";
 import { AUTOCOMPLETION_SYMBOLS } from "./symbols.js";
 import { DEFAULT_CODEMIRROR_TYPE_ICONS } from "./icons.js";
 import { matchBefore } from "./matchBefore.js";
 
-const TS_COMPLETE_BLOCKLIST: ScriptElementKind[] = [ScriptElementKind.warning];
+const TS_COMPLETE_BLOCKLIST: ts.ScriptElementKind[] = [
+  ts.ScriptElementKind.warning,
+];
 
 export async function getAutocompletion({
   env,

--- a/src/facet/tsFacet.ts
+++ b/src/facet/tsFacet.ts
@@ -1,5 +1,5 @@
 import { combineConfig, Facet } from "@codemirror/state";
-import { type VirtualTypeScriptEnvironment } from "@typescript/vfs";
+import type ts from "@typescript/vfs";
 
 /**
  * This is how the ts-related extensions are
@@ -11,11 +11,11 @@ import { type VirtualTypeScriptEnvironment } from "@typescript/vfs";
 export const tsFacet = Facet.define<
   {
     path: string;
-    env: VirtualTypeScriptEnvironment;
+    env: ts.VirtualTypeScriptEnvironment;
   },
   {
     path: string;
-    env: VirtualTypeScriptEnvironment;
+    env: ts.VirtualTypeScriptEnvironment;
   } | null
 >({
   combine(configs) {

--- a/src/hover/getHover.ts
+++ b/src/hover/getHover.ts
@@ -1,4 +1,4 @@
-import { type QuickInfo, type DefinitionInfo } from "typescript";
+import type ts from "typescript";
 import { type VirtualTypeScriptEnvironment } from "@typescript/vfs";
 
 /**
@@ -8,8 +8,8 @@ import { type VirtualTypeScriptEnvironment } from "@typescript/vfs";
 export interface HoverInfo {
   start: number;
   end: number;
-  typeDef: readonly DefinitionInfo[] | undefined;
-  quickInfo: QuickInfo | undefined;
+  typeDef: readonly ts.DefinitionInfo[] | undefined;
+  quickInfo: ts.QuickInfo | undefined;
 }
 
 export function getHover({

--- a/src/lint/utils.ts
+++ b/src/lint/utils.ts
@@ -1,8 +1,4 @@
-import {
-  type Diagnostic as TSDiagnostic,
-  type DiagnosticWithLocation,
-  DiagnosticCategory,
-} from "typescript";
+import ts from "typescript";
 import { type Diagnostic } from "@codemirror/lint";
 
 /**
@@ -11,20 +7,20 @@ import { type Diagnostic } from "@codemirror/lint";
  * Here, we do the mapping.
  */
 export function tsCategoryToSeverity(
-  diagnostic: Pick<DiagnosticWithLocation, "category" | "code">,
+  diagnostic: Pick<ts.DiagnosticWithLocation, "category" | "code">,
 ): Diagnostic["severity"] {
   if (diagnostic.code === 7027) {
     // Unreachable code detected
     return "warning";
   }
   switch (diagnostic.category) {
-    case DiagnosticCategory.Error:
+    case ts.DiagnosticCategory.Error:
       return "error";
-    case DiagnosticCategory.Message:
+    case ts.DiagnosticCategory.Message:
       return "info";
-    case DiagnosticCategory.Warning:
+    case ts.DiagnosticCategory.Warning:
       return "warning";
-    case DiagnosticCategory.Suggestion:
+    case ts.DiagnosticCategory.Suggestion:
       return "info";
   }
 }
@@ -35,8 +31,8 @@ export function tsCategoryToSeverity(
  * do.
  */
 export function isDiagnosticWithLocation(
-  diagnostic: TSDiagnostic,
-): diagnostic is DiagnosticWithLocation {
+  diagnostic: ts.Diagnostic,
+): diagnostic is ts.DiagnosticWithLocation {
   return !!(
     diagnostic.file &&
     typeof diagnostic.start === "number" &&
@@ -51,7 +47,7 @@ export function isDiagnosticWithLocation(
  * to get a string, regardless of which case we're in.
  */
 export function tsDiagnosticMessage(
-  diagnostic: Pick<TSDiagnostic, "messageText">,
+  diagnostic: Pick<ts.Diagnostic, "messageText">,
 ): string {
   if (typeof diagnostic.messageText === "string") {
     return diagnostic.messageText;
@@ -65,7 +61,9 @@ export function tsDiagnosticMessage(
  * ways of representing diagnostics. This converts
  * from one to the other.
  */
-export function convertTSDiagnosticToCM(d: DiagnosticWithLocation): Diagnostic {
+export function convertTSDiagnosticToCM(
+  d: ts.DiagnosticWithLocation,
+): Diagnostic {
   // We add some code at the end of the document, but we can't have a
   // diagnostic in an invalid range
   const start = d.start;


### PR DESCRIPTION
Uniformly use default export for ts, to maintain compatibility across a bunch of different bundlers.

- Fixes #28 