### PR TITLE
feat: add `diagnosticCodesToIgnore` on tsLinter

### DIFF
--- a/src/lint/getLints.ts
+++ b/src/lint/getLints.ts
@@ -1,3 +1,4 @@
+import type { DiagnosticWithLocation } from "typescript";
 import { convertTSDiagnosticToCM, isDiagnosticWithLocation } from "./utils.js";
 import { type VirtualTypeScriptEnvironment } from "@typescript/vfs";
 
@@ -11,9 +12,11 @@ import { type VirtualTypeScriptEnvironment } from "@typescript/vfs";
 export function getLints({
   env,
   path,
+  diagnosticCodesToIgnore,
 }: {
   env: VirtualTypeScriptEnvironment;
   path: string;
+  diagnosticCodesToIgnore: number[];
 }) {
   // Don't crash if the relevant file isn't created yet.
   const exists = env.getSourceFile(path);
@@ -23,7 +26,9 @@ export function getLints({
   const semanticDiagnostics = env.languageService.getSemanticDiagnostics(path);
 
   const diagnostics = [...syntaticDiagnostics, ...semanticDiagnostics].filter(
-    isDiagnosticWithLocation,
+    (diagnostic): diagnostic is DiagnosticWithLocation =>
+      isDiagnosticWithLocation(diagnostic) &&
+      !diagnosticCodesToIgnore.includes(diagnostic.code),
   );
 
   return diagnostics.map(convertTSDiagnosticToCM);

--- a/src/lint/tsLinter.ts
+++ b/src/lint/tsLinter.ts
@@ -8,9 +8,16 @@ import { tsFacet } from "../facet/tsFacet.js";
  * the `getLints` method for a lower-level interface
  * to the same data.
  */
-export function tsLinter() {
+export function tsLinter({
+  diagnosticCodesToIgnore,
+}: { diagnosticCodesToIgnore?: number[] } = {}) {
   return linter(async (view): Promise<readonly Diagnostic[]> => {
     const config = view.state.facet(tsFacet);
-    return config ? getLints(config) : [];
+    return config
+      ? getLints({
+          ...config,
+          diagnosticCodesToIgnore: diagnosticCodesToIgnore || [],
+        })
+      : [];
   });
 }

--- a/src/lint/tsLinterWorker.ts
+++ b/src/lint/tsLinterWorker.ts
@@ -7,9 +7,16 @@ import { tsFacetWorker } from "../index.js";
  * the `getLints` method for a lower-level interface
  * to the same data.
  */
-export function tsLinterWorker() {
+export function tsLinterWorker({
+  diagnosticCodesToIgnore,
+}: { diagnosticCodesToIgnore?: number[] } = {}) {
   return linter(async (view): Promise<readonly Diagnostic[]> => {
     const config = view.state.facet(tsFacetWorker);
-    return config ? config.worker.getLints({ path: config.path }) : [];
+    return config
+      ? config.worker.getLints({
+          path: config.path,
+          diagnosticCodesToIgnore: diagnosticCodesToIgnore || [],
+        })
+      : [];
   });
 }

--- a/src/worker/createWorker.ts
+++ b/src/worker/createWorker.ts
@@ -41,9 +41,15 @@ export function createWorker(
       if (!env) return;
       createOrUpdateFile(env, path, code);
     },
-    getLints({ path }: { path: string }) {
+    getLints({
+      path,
+      diagnosticCodesToIgnore,
+    }: {
+      path: string;
+      diagnosticCodesToIgnore: number[];
+    }) {
       if (!env) return [];
-      return getLints({ env, path });
+      return getLints({ env, path, diagnosticCodesToIgnore });
     },
     getAutocompletion({
       path,
@@ -60,7 +66,7 @@ export function createWorker(
       return getHover({ env, path, pos });
     },
     getEnv() {
-        return env
-    }
+      return env;
+    },
   };
 }


### PR DESCRIPTION
Add a way to ignore diagnostic codes, similar to https://microsoft.github.io/monaco-editor/typedoc/interfaces/languages.typescript.DiagnosticsOptions.html#diagnosticCodesToIgnore

```ts
tsLinter({
    diagnosticCodesToIgnore: [
        2354, // tslib not found
		2307, // Cannot find module 'xxx' or its corresponding type declarations
		1375, // 'await' expressions are only allowed at the top level of a file when that file is a module
    ],
}),
```