### PR TITLE
First pass external types support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 dist
 .DS_Store
+.aider*
+.env

--- a/README.md
+++ b/README.md
@@ -31,6 +31,42 @@ have direct dependencies to:
 Below are recipes for setting up this code - check out the StackBlitz
 demos above if you want easily copy-paste-able code!
 
+## Using External Libraries
+
+To use external libraries like React, Lodash, or D3, you'll need to configure the TypeScript environment with their type definitions. Here are some examples:
+
+```ts
+// Example with React, Lodash, and D3
+const libraries = {
+  "react": "https://cdn.jsdelivr.net/npm/@types/react@18.2.0/index.d.ts",
+  "lodash": "https://cdn.jsdelivr.net/npm/@types/lodash@4.14.195/index.d.ts",
+  "d3": "https://cdn.jsdelivr.net/npm/@types/d3@7.4.0/index.d.ts"
+};
+
+// For main thread usage:
+let editor = new EditorView({
+  extensions: [
+    basicSetup,
+    javascript({
+      typescript: true,
+      jsx: true,
+    }),
+    tsFacet.of({ env, path, libraries }),
+    tsSync(),
+  ],
+  parent: document.querySelector("#editor")
+});
+
+// For worker usage:
+const extensions = [
+  tsFacetWorker.of({ worker, path, libraries }),
+  tsSyncWorker(),
+  // ... other extensions
+];
+```
+
+The `libraries` object maps library names to their TypeScript definition URLs. You can use any TypeScript definition file hosted on CDNs like jsdelivr or unpkg.
+
 ## Setup (main thread)
 
 This is the simplest way to use this code: you'll be running

--- a/demo/worker.ts
+++ b/demo/worker.ts
@@ -7,16 +7,69 @@ import ts from "typescript";
 import * as Comlink from "comlink";
 import { createWorker } from "../src/worker/createWorker.js";
 
+async function fetchTypeDefinition(url: string) {
+  const response = await fetch(url);
+  return response.text();
+}
+
 Comlink.expose(
   createWorker(async function () {
+    // Default TypeScript lib files
     const fsMap = await createDefaultMapFromCDN(
       { target: ts.ScriptTarget.ES2022 },
       "3.7.3",
       false,
       ts,
     );
+
+    // Common library type definitions with their dependencies
+    const librariesConfig = {
+      'lodash': {
+        main: 'https://cdn.jsdelivr.net/npm/@types/lodash@4.14.195/index.d.ts'
+      },
+      'react': {
+        main: 'https://cdn.jsdelivr.net/npm/@types/react@18.2.0/index.d.ts'
+      },
+      'd3': {
+        main: 'https://cdn.jsdelivr.net/npm/@types/d3@7.4.0/index.d.ts',
+        deps: {
+          'd3-selection': 'https://cdn.jsdelivr.net/npm/@types/d3-selection@3.0.10/index.d.ts',
+          'd3-transition': 'https://cdn.jsdelivr.net/npm/@types/d3-transition@3.0.8/index.d.ts',
+          'd3-scale': 'https://cdn.jsdelivr.net/npm/@types/d3-scale@4.0.8/index.d.ts'
+        }
+      }
+    };
+
+    // Load library type definitions and their dependencies
+    for (const [name, config] of Object.entries(librariesConfig)) {
+      try {
+        // Load main type definition
+        const mainDefs = await fetchTypeDefinition(config.main);
+        fsMap.set(`node_modules/@types/${name}/index.d.ts`, mainDefs);
+        
+        // Load dependencies if any
+        if (config.deps) {
+          for (const [depName, depUrl] of Object.entries(config.deps)) {
+            const depDefs = await fetchTypeDefinition(depUrl);
+            fsMap.set(`node_modules/@types/${depName}/index.d.ts`, depDefs);
+          }
+        }
+      } catch (err) {
+        console.warn(`Failed to load type definitions for ${name}:`, err);
+      }
+    }
+
     const system = createSystem(fsMap);
-    const compilerOpts = {};
+    const compilerOpts = {
+      target: ts.ScriptTarget.ES2022,
+      moduleResolution: ts.ModuleResolutionKind.NodeJs,
+      module: ts.ModuleKind.ESNext,
+      allowJs: true,
+      typeRoots: ["node_modules/@types"],
+      types: ["d3", "d3-selection", "d3-transition", "d3-scale", "lodash", "react"],
+      skipLibCheck: true
+    };
+
     return createVirtualTypeScriptEnvironment(system, [], ts, compilerOpts);
   }),
 );

--- a/src/facet/tsFacet.ts
+++ b/src/facet/tsFacet.ts
@@ -8,17 +8,20 @@ import type ts from "@typescript/vfs";
  * the extensions, like tsLint and tsAutocomplete,
  * pull those settings automatically from editor state.
  */
+export interface TSFacetConfig {
+  path: string;
+  env: ts.VirtualTypeScriptEnvironment;
+  keepLegacyLimitationForAutocompletionSymbols?: boolean;
+  /**
+   * External library configurations.
+   * Key is the library name, value is the types URL or content
+   */
+  libraries?: Record<string, string>;
+}
+
 export const tsFacet = Facet.define<
-  {
-    path: string;
-    env: ts.VirtualTypeScriptEnvironment;
-    keepLegacyLimitationForAutocompletionSymbols?: boolean;
-  },
-  {
-    path: string;
-    env: ts.VirtualTypeScriptEnvironment;
-    keepLegacyLimitationForAutocompletionSymbols?: boolean;
-  } | null
+  TSFacetConfig,
+  TSFacetConfig | null
 >({
   combine(configs) {
     return combineConfig(configs, {});

--- a/src/facet/tsFacetWorker.ts
+++ b/src/facet/tsFacetWorker.ts
@@ -11,15 +11,19 @@ import { type WorkerShape } from "../worker.js";
  * the extensions, like tsLint and tsAutocomplete,
  * pull those settings automatically from editor state.
  */
+export interface TSFacetWorkerConfig {
+  path: string;
+  worker: WorkerShape;
+  /**
+   * External library configurations.
+   * Key is the library name, value is the types URL or content
+   */
+  libraries?: Record<string, string>;
+}
+
 export const tsFacetWorker = Facet.define<
-  {
-    path: string;
-    worker: WorkerShape;
-  },
-  {
-    path: string;
-    worker: WorkerShape;
-  } | null
+  TSFacetWorkerConfig,
+  TSFacetWorkerConfig | null
 >({
   combine(configs) {
     return combineConfig(configs, {});

--- a/src/lint/getLints.ts
+++ b/src/lint/getLints.ts
@@ -13,10 +13,12 @@ export function getLints({
   env,
   path,
   diagnosticCodesToIgnore,
+  libraries,
 }: {
   env: VirtualTypeScriptEnvironment;
   path: string;
   diagnosticCodesToIgnore: number[];
+  libraries?: Record<string, string>;
 }) {
   // Don't crash if the relevant file isn't created yet.
   const exists = env.getSourceFile(path);

--- a/src/lint/tsLinter.ts
+++ b/src/lint/tsLinter.ts
@@ -17,6 +17,7 @@ export function tsLinter({
       ? getLints({
           ...config,
           diagnosticCodesToIgnore: diagnosticCodesToIgnore || [],
+          libraries: config.libraries,
         })
       : [];
   });

--- a/src/lint/tsLinterWorker.ts
+++ b/src/lint/tsLinterWorker.ts
@@ -16,6 +16,7 @@ export function tsLinterWorker({
       ? config.worker.getLints({
           path: config.path,
           diagnosticCodesToIgnore: diagnosticCodesToIgnore || [],
+          libraries: config.libraries,
         })
       : [];
   });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,3 +1,9 @@
+export interface GetLintsParams {
+  path: string;
+  diagnosticCodesToIgnore: number[];
+  libraries?: Record<string, string>;
+}
+
 export * from "./hover/getHover.js";
 export * from "./autocomplete/getAutocompletion.js";
 export * from "./lint/getLints.js";

--- a/src/worker/createWorker.ts
+++ b/src/worker/createWorker.ts
@@ -44,12 +44,14 @@ export function createWorker(
     getLints({
       path,
       diagnosticCodesToIgnore,
+      libraries,
     }: {
       path: string;
       diagnosticCodesToIgnore: number[];
+      libraries?: Record<string, string>;
     }) {
       if (!env) return [];
-      return getLints({ env, path, diagnosticCodesToIgnore });
+      return getLints({ env, path, diagnosticCodesToIgnore, libraries });
     },
     getAutocompletion({
       path,


### PR DESCRIPTION
This PR introduces a new argument `libraries` that looks something like this:

```js
// Example with React, Lodash, and D3
const libraries = {
  "react": "https://cdn.jsdelivr.net/npm/@types/react@18.2.0/index.d.ts",
  "lodash": "https://cdn.jsdelivr.net/npm/@types/lodash@4.14.195/index.d.ts",
  "d3": "https://cdn.jsdelivr.net/npm/@types/d3@7.4.0/index.d.ts"
};
```

This setup does not pull in arbitrary packages referenced in code, but rather forces the editor author to configure each library separately and pass the config into the CodeMirror extension. This solution is not as generic as something like https://github.com/val-town/deno-ata , but it's also a much lighter weight solution suitable for editing environments where a limited number of libraries are expected to be used. My main use case is for the VizHub editor, which primarily deals with D3 examples.

Closes #40

Closes #27 