### PR TITLE
Omit initialize from WorkerShape.initialize FacetConfig

### DIFF
--- a/src/facet/tsFacet.ts
+++ b/src/facet/tsFacet.ts
@@ -14,7 +14,7 @@ import type { WorkerShape } from "../worker/createWorker.js";
 export const tsFacet = Facet.define<
   {
     path: string;
-    worker: WorkerShape;
+    worker: Omit<WorkerShape, "initialize">;
     log?: (...args: unknown[]) => void;
   },
   FacetConfig
@@ -26,6 +26,6 @@ export const tsFacet = Facet.define<
 
 export type FacetConfig = {
   path: string;
-  worker: WorkerShape;
+  worker: Omit<WorkerShape, "initialize">;
   log?: (...args: unknown[]) => void;
 } | null;


### PR DESCRIPTION
Allows custom `initialize` method. 