### PR TITLE
Pass getDefinitionAtPosition separately via HoverInfo

### DIFF
--- a/src/goto/tsGoto.ts
+++ b/src/goto/tsGoto.ts
@@ -13,7 +13,10 @@ export function defaultGotoHandler(
   hoverData: HoverInfo,
   view: EditorView,
 ) {
-  const definition = hoverData?.typeDef?.at(0);
+  const definition = [
+    ...(hoverData.typeDef ? hoverData.typeDef : []),
+    ...(hoverData.def ? hoverData.def : [])
+  ]?.at(0);
 
   if (definition && currentPath === definition.fileName) {
     const tr = view.state.update({

--- a/src/hover/getHover.ts
+++ b/src/hover/getHover.ts
@@ -8,7 +8,10 @@ import type ts from "typescript";
 export interface HoverInfo {
   start: number;
   end: number;
+  /** Type definitions returned by ts.LanguageService.getTypeDefinitionAtPosition() */
   typeDef: readonly ts.DefinitionInfo[] | undefined;
+  /** Definitions returned by ts.LanguageService.getDefinitionAtPosition() */
+  def: readonly ts.DefinitionInfo[] | undefined;
   quickInfo: ts.QuickInfo | undefined;
 }
 
@@ -35,13 +38,15 @@ export function getHover({
     const start = quickInfo.textSpan.start;
 
     const typeDef =
-      env.languageService.getTypeDefinitionAtPosition(path, sourcePos) ??
+      env.languageService.getTypeDefinitionAtPosition(path, sourcePos);
+    const def =
       env.languageService.getDefinitionAtPosition(path, sourcePos);
 
     return {
       start,
       end: start + quickInfo.textSpan.length,
       typeDef,
+      def,
       quickInfo,
     };
   } catch (e) {

--- a/src/hover/renderTooltip.test.ts
+++ b/src/hover/renderTooltip.test.ts
@@ -13,6 +13,7 @@ test("defaultRenderer", () => {
         start: 0,
         end: 1,
         typeDef: undefined,
+        def: undefined,
         quickInfo: undefined,
       },
       view,


### PR DESCRIPTION
The definitions returned by `getTypeDefinitionAtPosition()` are sometimes not helpful for implementing go to definition. For example:

```ts
const someFunc: SomeType = () => {
}

someFunc();
```

If you try to jump to the `someFunc()` definition here, you will only have a type definition for `SomeType`, not for the variable definition of `someFunc`.

This PR splits makes the definition and type definition available in `HoverInfo` separately. It keeps the behavior of the default go to definition implementation, although it should probably be improved.